### PR TITLE
updated DOCKERFILE FROM line to specify platform as linux/x86_64

### DIFF
--- a/code/Dockerfile
+++ b/code/Dockerfile
@@ -1,5 +1,5 @@
 #FROM --platform=linux/x86_64 python:3.9
-FROM public.ecr.aws/lambda/python:3.9
+FROM --platform=linux/x86_64 public.ecr.aws/lambda/python:3.9
 # FROM amazon/aws-lambda-python:latest
 # Copy function code
 COPY requirements.txt .


### PR DESCRIPTION
updated FROM line to specify platform as linux/x86_64. This allows the docker build on ARM Macs to build the same as on intel.